### PR TITLE
Improve course cards and add course detail routing

### DIFF
--- a/courses/html/metadata.md
+++ b/courses/html/metadata.md
@@ -3,4 +3,5 @@ title: "HTML"
 description: "Learn HTML - Basics to Advanced"
 logo: ""
 banner: ""
+rootColor: "#e34f26"
 ---

--- a/courses/html/metadata.md
+++ b/courses/html/metadata.md
@@ -1,7 +1,7 @@
 ---
 title: "HTML"
 description: "Learn HTML - Basics to Advanced"
-logo: ""
+logo: "/icons/skills/ic-html.svg"
 banner: ""
 rootColor: "#e34f26"
 ---

--- a/courses/javascript/metadata.md
+++ b/courses/javascript/metadata.md
@@ -1,7 +1,7 @@
 ---
 title: "JavaScript"
 description: "Learn JavaScript - Basics to Advanced"
-logo: ""
+logo: "/icons/skills/ic-javascript.svg"
 banner: ""
 rootColor: "#f7df1e"
 ---

--- a/courses/javascript/metadata.md
+++ b/courses/javascript/metadata.md
@@ -3,4 +3,5 @@ title: "JavaScript"
 description: "Learn JavaScript - Basics to Advanced"
 logo: ""
 banner: ""
+rootColor: "#f7df1e"
 ---

--- a/src/app/courses/[slug]/page.tsx
+++ b/src/app/courses/[slug]/page.tsx
@@ -1,1 +1,38 @@
-export default function Page() {}
+import { notFound } from "next/navigation";
+
+import Box from "@mui/material/Box";
+import Container from "@mui/material/Container";
+import Typography from "@mui/material/Typography";
+
+import { getCourseBySlug } from "@/lib/courses";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const course = getCourseBySlug(slug);
+
+  if (!course) notFound();
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 6 }}>
+      <Box
+        sx={{
+          p: 4,
+          borderRadius: 3,
+          color: "common.white",
+          background: `linear-gradient(135deg, ${course.rootColor || "#1f2937"} 0%, #0f172a 100%)`,
+        }}
+      >
+        <Typography variant="h3" sx={{ fontWeight: 700 }}>
+          {course.title}
+        </Typography>
+        <Typography variant="h6" sx={{ mt: 1, opacity: 0.9 }}>
+          {course.description}
+        </Typography>
+      </Box>
+    </Container>
+  );
+}

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -9,7 +9,5 @@ export const metadata: Metadata = { title: "Courses | thatonevikash" };
 export default function Page() {
   const courses = getAllCourses();
 
-  console.log(courses);
-
   return <CourseRootView courses={courses} />;
 }

--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -5,10 +5,12 @@ import matter from "gray-matter";
 import { paths } from "@/paths";
 
 export interface CourseMetadata {
+  slug: string;
   title: string;
   description: string;
   logo: string | undefined;
   banner: string | undefined;
+  rootColor: string | undefined;
 }
 
 export function getAllCourses(): Omit<CourseMetadata, "banner">[] {
@@ -24,9 +26,29 @@ export function getAllCourses(): Omit<CourseMetadata, "banner">[] {
       const { data } = matter(raw);
 
       return {
+        slug: dirname,
         title: data.title,
         description: data.description,
         logo: data.logo,
+        rootColor: data.rootColor,
       };
     });
+}
+
+export function getCourseBySlug(slug: string): CourseMetadata | null {
+  const metadataPath = path.join(paths.courses, slug, "metadata.md");
+
+  if (!fs.existsSync(metadataPath)) return null;
+
+  const raw = fs.readFileSync(metadataPath, "utf-8");
+  const { data } = matter(raw);
+
+  return {
+    slug,
+    title: data.title,
+    description: data.description,
+    logo: data.logo,
+    banner: data.banner,
+    rootColor: data.rootColor,
+  };
 }

--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -4,6 +4,8 @@ import matter from "gray-matter";
 
 import { paths } from "@/paths";
 
+import { normalizeLocalAssetSrc } from "./normalize-local-asset-src";
+
 export interface CourseMetadata {
   slug: string;
   title: string;
@@ -29,7 +31,7 @@ export function getAllCourses(): Omit<CourseMetadata, "banner">[] {
         slug: dirname,
         title: data.title,
         description: data.description,
-        logo: data.logo,
+        logo: normalizeLocalAssetSrc(data.logo),
         rootColor: data.rootColor,
       };
     });
@@ -47,7 +49,7 @@ export function getCourseBySlug(slug: string): CourseMetadata | null {
     slug,
     title: data.title,
     description: data.description,
-    logo: data.logo,
+    logo: normalizeLocalAssetSrc(data.logo),
     banner: data.banner,
     rootColor: data.rootColor,
   };

--- a/src/lib/normalize-local-asset-src.ts
+++ b/src/lib/normalize-local-asset-src.ts
@@ -1,0 +1,36 @@
+const docsBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "/docs";
+
+function normalizeBasePath(basePath: string): string {
+  if (!basePath || basePath === "/") return "";
+  return basePath.startsWith("/")
+    ? basePath.replace(/\/$/, "")
+    : `/${basePath.replace(/\/$/, "")}`;
+}
+
+function isExternalOrFragment(src: string): boolean {
+  return (
+    src.startsWith("http://") ||
+    src.startsWith("https://") ||
+    src.startsWith("//") ||
+    src.startsWith("data:") ||
+    src.startsWith("#")
+  );
+}
+
+export function normalizeLocalAssetSrc(src?: string): string | undefined {
+  if (!src) return undefined;
+  if (isExternalOrFragment(src)) return src;
+
+  const basePath = normalizeBasePath(docsBasePath);
+  if (!basePath) return src;
+
+  if (src === basePath || src.startsWith(`${basePath}/`)) {
+    return src;
+  }
+
+  if (src.startsWith("/")) {
+    return `${basePath}${src}`;
+  }
+
+  return `${basePath}/${src.replace(/^\.\//, "")}`;
+}

--- a/src/sections/root/course/view.tsx
+++ b/src/sections/root/course/view.tsx
@@ -5,6 +5,7 @@ import Link from "@mui/material/Link";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
 import CardActionArea from "@mui/material/CardActionArea";
+import Image from "next/image";
 
 import { CourseMetadata } from "@/lib/courses";
 
@@ -50,13 +51,12 @@ export function CourseRootView({
               component={Link}
               href={`/courses/${course.slug}`}
               underline="none"
-              sx={{ p: 2.5 }}
+              sx={{ p: 0 }}
             >
               <Box
                 sx={{
                   minHeight: 160,
-                  borderRadius: 2,
-                  p: 2,
+                  p: 2.5,
                   color: "common.white",
                   background: `linear-gradient(135deg, ${course.rootColor || "#1f2937"} 0%, #0f172a 100%)`,
                   display: "flex",
@@ -64,9 +64,18 @@ export function CourseRootView({
                   justifyContent: "space-between",
                 }}
               >
-                <Typography variant="subtitle2" sx={{ opacity: 0.9 }}>
-                  {course.logo || "📘"}
-                </Typography>
+                {course.logo ? (
+                  <Image
+                    src={course.logo}
+                    alt={`${course.title} logo`}
+                    width={32}
+                    height={32}
+                  />
+                ) : (
+                  <Typography variant="subtitle2" sx={{ opacity: 0.9 }}>
+                    📘
+                  </Typography>
+                )}
                 <Box>
                   <Typography variant="h5" sx={{ fontWeight: 700 }}>
                     {course.title}

--- a/src/sections/root/course/view.tsx
+++ b/src/sections/root/course/view.tsx
@@ -1,8 +1,10 @@
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import Card from "@mui/material/Card";
+import Link from "@mui/material/Link";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
+import CardActionArea from "@mui/material/CardActionArea";
 
 import { CourseMetadata } from "@/lib/courses";
 
@@ -41,12 +43,40 @@ export function CourseRootView({
           <Card
             component={Grid}
             size={{ xs: 6, md: 4 }}
-            key={course.title}
-            sx={{ p: 2, borderRadius: 3 }}
+            key={course.slug}
+            sx={{ borderRadius: 3, overflow: "hidden" }}
           >
-            <Typography variant="h5" sx={{ fontWeight: 600 }}>
-              {course.title}
-            </Typography>
+            <CardActionArea
+              component={Link}
+              href={`/courses/${course.slug}`}
+              underline="none"
+              sx={{ p: 2.5 }}
+            >
+              <Box
+                sx={{
+                  minHeight: 160,
+                  borderRadius: 2,
+                  p: 2,
+                  color: "common.white",
+                  background: `linear-gradient(135deg, ${course.rootColor || "#1f2937"} 0%, #0f172a 100%)`,
+                  display: "flex",
+                  flexDirection: "column",
+                  justifyContent: "space-between",
+                }}
+              >
+                <Typography variant="subtitle2" sx={{ opacity: 0.9 }}>
+                  {course.logo || "📘"}
+                </Typography>
+                <Box>
+                  <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                    {course.title}
+                  </Typography>
+                  <Typography variant="body2" sx={{ opacity: 0.8, mt: 0.5 }}>
+                    {course.description}
+                  </Typography>
+                </Box>
+              </Box>
+            </CardActionArea>
           </Card>
         ))}
       </Grid>

--- a/src/sections/root/course/view.tsx
+++ b/src/sections/root/course/view.tsx
@@ -49,7 +49,7 @@ export function CourseRootView({
           >
             <CardActionArea
               component={Link}
-              href={`/courses/${course.slug}`}
+              href={`/docs/courses/${course.slug}`}
               underline="none"
               sx={{ p: 0 }}
             >
@@ -58,7 +58,7 @@ export function CourseRootView({
                   minHeight: 160,
                   p: 2.5,
                   color: "common.white",
-                  background: `linear-gradient(135deg, ${course.rootColor || "#1f2937"} 0%, #0f172a 100%)`,
+                  background: `linear-gradient(135deg, ${course.rootColor || "#1f2937"} 5%, #0f172a 200%)`,
                   display: "flex",
                   flexDirection: "column",
                   justifyContent: "space-between",
@@ -68,8 +68,8 @@ export function CourseRootView({
                   <Image
                     src={course.logo}
                     alt={`${course.title} logo`}
-                    width={32}
-                    height={32}
+                    width={56}
+                    height={56}
                   />
                 ) : (
                   <Typography variant="subtitle2" sx={{ opacity: 0.9 }}>


### PR DESCRIPTION
### Motivation
- Provide richer course listing UI with per-course theming driven by metadata to make course cards visually distinct.
- Enable navigation to a course detail page by slug so each course can have its own dedicated route and hero header.

### Description
- Expanded `CourseMetadata` to include `slug` and `rootColor` and added `getCourseBySlug(slug)` in `src/lib/courses.ts` to load metadata by slug.
- Reworked the courses grid UI in `src/sections/root/course/view.tsx` to use `CardActionArea` with a gradient background based on `rootColor`, show title, description and a logo fallback, and link each card to `/courses/[slug]`.
- Implemented the dynamic course page in `src/app/courses/[slug]/page.tsx` to load metadata via `getCourseBySlug` and render a hero section using the same gradient treatment and `notFound()` for missing slugs.
- Added example `rootColor` entries to `courses/html/metadata.md` and `courses/javascript/metadata.md` and removed a debug `console.log` from the courses index page.

### Testing
- Ran `npm run lint` and the lint job completed successfully.
- No additional automated unit or integration tests were present or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff4da73c6c83319683687736d7a6e4)