### PR TITLE
Add chapter sidebar scaffolding to course detail page

### DIFF
--- a/src/app/courses/[slug]/page.tsx
+++ b/src/app/courses/[slug]/page.tsx
@@ -1,10 +1,14 @@
 import { notFound } from "next/navigation";
 
 import Box from "@mui/material/Box";
+import List from "@mui/material/List";
+import Paper from "@mui/material/Paper";
+import ListItem from "@mui/material/ListItem";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
+import ListItemText from "@mui/material/ListItemText";
 
-import { getCourseBySlug } from "@/lib/courses";
+import { getCourseBySlug, getCourseChapters } from "@/lib/courses";
 
 export default async function Page({
   params,
@@ -13,6 +17,7 @@ export default async function Page({
 }) {
   const { slug } = await params;
   const course = getCourseBySlug(slug);
+  const chapters = getCourseChapters(slug);
 
   if (!course) notFound();
 
@@ -32,6 +37,45 @@ export default async function Page({
         <Typography variant="h6" sx={{ mt: 1, opacity: 0.9 }}>
           {course.description}
         </Typography>
+      </Box>
+
+      <Box
+        sx={{
+          mt: 4,
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "300px 1fr" },
+          gap: 3,
+        }}
+      >
+        <Paper elevation={0} sx={{ p: 2, bgcolor: "transparent" }}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 1.5 }}>
+            Chapters
+          </Typography>
+
+          <List disablePadding>
+            {chapters.map((chapter) => (
+              <ListItem
+                key={chapter.slug}
+                sx={{ px: 0, py: 1, borderBottom: "1px solid", borderColor: "divider" }}
+              >
+                <ListItemText
+                  primary={chapter.title}
+                  secondary={chapter.fileName}
+                  primaryTypographyProps={{ fontWeight: 500 }}
+                />
+              </ListItem>
+            ))}
+          </List>
+        </Paper>
+
+        <Box sx={{ p: 2.5, borderRadius: 2, border: "1px dashed", borderColor: "divider" }}>
+          <Typography variant="h6" sx={{ fontWeight: 600, mb: 1 }}>
+            Chapter content area
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Content rendering will be implemented in the next step.
+          </Typography>
+        </Box>
       </Box>
     </Container>
   );

--- a/src/app/courses/[slug]/page.tsx
+++ b/src/app/courses/[slug]/page.tsx
@@ -8,7 +8,11 @@ import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
 import ListItemText from "@mui/material/ListItemText";
 
-import { getCourseBySlug, getCourseChapters } from "@/lib/courses";
+import { getAllCourses, getCourseBySlug, getCourseChapters } from "@/lib/courses";
+
+export async function generateStaticParams() {
+  return getAllCourses().map((course) => ({ slug: course.slug }));
+}
 
 export default async function Page({
   params,

--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -15,6 +15,12 @@ export interface CourseMetadata {
   rootColor: string | undefined;
 }
 
+export interface CourseChapter {
+  slug: string;
+  fileName: string;
+  title: string;
+}
+
 export function getAllCourses(): Omit<CourseMetadata, "banner">[] {
   const courses = fs.readdirSync(paths.courses);
 
@@ -53,4 +59,26 @@ export function getCourseBySlug(slug: string): CourseMetadata | null {
     banner: data.banner,
     rootColor: data.rootColor,
   };
+}
+
+export function getCourseChapters(slug: string): CourseChapter[] {
+  const coursePath = path.join(paths.courses, slug);
+
+  if (!fs.existsSync(coursePath)) return [];
+
+  return fs
+    .readdirSync(coursePath)
+    .filter((fileName) => /^\d+_.+\.md$/i.test(fileName))
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+    .map((fileName) => {
+      const chapterPath = path.join(coursePath, fileName);
+      const raw = fs.readFileSync(chapterPath, "utf-8");
+      const { data } = matter(raw);
+
+      return {
+        slug: fileName.replace(/\.md$/i, ""),
+        fileName,
+        title: data.title || fileName.replace(/\.md$/i, ""),
+      };
+    });
 }


### PR DESCRIPTION
### Motivation
- Provide a chapter navigation sidebar for course pages so chapters (stored as `01_*.md`, `02_*.md`, ...) can be listed and navigated in order.
- Preserve the numeric ordering specified by filename prefixes and keep the page layout consistent with other routes via `Container maxWidth="lg"`.
- Make the sidebar visually blend with the course header background by keeping the MUI surface transparent.

### Description
- Added a `CourseChapter` interface and a new `getCourseChapters(slug)` helper in `src/lib/courses.ts` that discovers files matching the pattern `^\d+_.+\.md$`, sorts them using `localeCompare` with numeric comparison, and reads frontmatter `title` for display.
- Updated `src/app/courses/[slug]/page.tsx` to call `getCourseChapters` and render a two-column grid inside `Container maxWidth="lg"` with a left sidebar (chapter list) and a right placeholder content area for later content rendering.
- Implemented the sidebar using MUI `Paper` with `bgcolor: "transparent"` and a `List`/`ListItem` layout showing chapter frontmatter `title` and filename as secondary text.

### Testing
- Ran `npm run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff58f64c5c8331ad808b8d608beae1)